### PR TITLE
[update]refs #11 style.cssの汎用性の向上

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -112,7 +112,7 @@ img {
 /* -------------------------------------------- */
 @media screen and (min-width: 700px) {
 
-    #pageHead .globalHead {
+    #pageHead #globalHead {
         display: flex;
         justify-content: space-between;
     }

--- a/css/style.css
+++ b/css/style.css
@@ -50,6 +50,18 @@ img {
     margin: 0 auto;
 }
 
+/* side padding for narrow screen */
+.contentsSidePadding {
+    padding: 0 1em;
+}
+@media screen and (min-width: 1080px) {
+
+    .contentsSidePadding {
+        padding: 0;
+    }
+}
+
+
 /* page header */
 /* ============================================ */
 
@@ -104,23 +116,11 @@ img {
         display: flex;
         justify-content: space-between;
     }
-    #pageHead .siteLogo {
-        margin: 0 0 0 1em;
-    }
     #pageHead .globalNavi {
-        padding: 2em 1em 0 0;
+        padding: 2em 0;
     }
     #pageHead .globalNavi ul li {
         font-size: 1.35em;
-    }
-}
-@media screen and (min-width: 1080px) {
-
-    #pageHead .siteLogo {
-        margin: 0;
-    }
-    #pageHead .globalNavi {
-        padding: 2em 0 0;
     }
 }
 
@@ -168,19 +168,6 @@ img {
 #pageBody {
     padding: 3em 0 0;
     background: rgb(255, 255, 255)
-}
-
-/* side padding of contents for narrow screen */
-#pageBody main,
-#pageBody aside {
-    padding: 0 1em;
-}
-@media screen and (min-width: 1080px) {
-
-    #pageBody main,
-    #pageBody aside {
-        padding: 0;
-    }
 }
 
 /* p */

--- a/css/style.css
+++ b/css/style.css
@@ -44,10 +44,8 @@ img {
     display: block;
 }
 
-/* max width of max width */
-#pageHead,
-#pageBody,
-#pageFoot {
+/* max width of contents */
+.contentsMaxWidth {
     max-width: 980px;
     margin: 0 auto;
 }
@@ -56,10 +54,10 @@ img {
 /* ============================================ */
 
 /* page head background */
-#pageHeadWrap {
+#pageHead {
     background: 0% 0% / cover no-repeat;
 }
-#pageHeadWrap.page_news{
+#pageHead.page_news {
     background-image: url(../images/news/news-bg.jpg);
 }
 
@@ -154,7 +152,7 @@ img {
 /* page footer */
 /* ============================================ */
 
-#pageFootWrap {
+#pageFoot {
     color: rgb(230, 230, 230);
     background: rgb(53, 37, 12);
 }
@@ -167,7 +165,7 @@ img {
 /* page body */
 /* ============================================ */
 
-#pageBodyWrap {
+#pageBody {
     padding: 3em 0 0;
     background: rgb(255, 255, 255)
 }

--- a/news.html
+++ b/news.html
@@ -23,8 +23,8 @@
 <body>
 <div id="page" class="page_news">
 
-    <div id="pageHeadWrap" class="page_news">
-        <header id="pageHead" class="page_news">
+    <header id="pageHead" class="page_news">
+        <div class="contentsMaxWidth page_news">
             <div class="globalHead page_news">
                 <a href="./index.html#page"><img src="./images/common/logo.svg" width="426" height="148" alt="GFTD.CAFE" title="GFTD.CAFE トップページ" class="siteLogo page_news"></a>
                 <nav class="globalNavi page_news">
@@ -38,11 +38,11 @@
             <div class="localHead page_news">
                 <h1 class="pageTitle page_news">NEWS</h1>
             </div>
-        </header>
-    </div> <!-- /#pageBodyWrap -->
+        </div>
+    </header> <!-- /#pageHead -->
 
-    <div id="pageBodyWrap" class="page_news">
-        <div id="pageBody" class="page_news">
+    <div id="pageBody" class="page_news">
+        <div class="contentsMaxWidth page_news">
             <div class="pageBodyFlexbox page_news">
     
                 <main class="mainColumn page_news">
@@ -57,10 +57,10 @@
                                     </tr>
                                 </table>
                             </div>
-                                <div class="articleDate page_news">
-                                    <div class="articleMMDD page_news"><time datetime="2019-04-01">4/01</time></div>
-                                    <div class="articleYYYY page_news">2019</div>
-                                </div>
+                            <div class="articleDate page_news">
+                                <div class="articleMMDD page_news"><time datetime="2019-04-01">4/01</time></div>
+                                <div class="articleYYYY page_news">2019</div>
+                            </div>
                         </div> <!-- /.articleTop -->
                         <img src="./images/news/wall.jpg" width="1600" height="1010" alt="" class="articlePicture page_news">
                         <p>
@@ -101,14 +101,14 @@
                 </aside>
     
             </div> <!-- /.pageBodyFlexbox -->
-        </div> <!-- /#pageBody-->
-    </div> <!-- /#pageBodyWrap -->
+        </div> <!-- /.contentsMaxWidth -->
+    </div> <!-- /#pageBody -->
 
-    <div id="pageFootWrap" class="page_news">
-        <footer id="pageFoot" class="page_news">
+    <footer id="pageFoot" class="page_news">
+        <div class="contentsMaxWidth page_news">
             <p id="copyright" class="page_news"><small>&copy; 2019 GFTD.WORKS</small></p>
-        </footer>
-    </div>
+        </div>
+    </footer>
 
 </div> <!-- /#page -->
 </body>

--- a/news.html
+++ b/news.html
@@ -25,88 +25,94 @@
 
     <header id="pageHead" class="page_news">
         <div class="contentsMaxWidth page_news">
-            <div class="globalHead page_news">
-                <a href="./index.html#page"><img src="./images/common/logo.svg" width="426" height="148" alt="GFTD.CAFE" title="GFTD.CAFE トップページ" class="siteLogo page_news"></a>
-                <nav class="globalNavi page_news">
-                    <ul>
-                        <li><a href="#page">NEWS</a></li>
-                        <li><a href="./menu.html#page">MENU</a></li>
-                        <li><a href="./contact.html#page">CONTACT</a></li>
-                    </ul>
-                </nav>
-            </div>
-            <div class="localHead page_news">
-                <h1 class="pageTitle page_news">NEWS</h1>
-            </div>
-        </div>
+            <div class="contentsSidePadding page_news">
+                <div class="globalHead page_news">
+                    <a href="./index.html#page"><img src="./images/common/logo.svg" width="426" height="148" alt="GFTD.CAFE" title="GFTD.CAFE トップページ" class="siteLogo page_news"></a>
+                    <nav class="globalNavi page_news">
+                        <ul>
+                            <li><a href="#page">NEWS</a></li>
+                            <li><a href="./menu.html#page">MENU</a></li>
+                            <li><a href="./contact.html#page">CONTACT</a></li>
+                        </ul>
+                    </nav>
+                </div>
+                <div class="localHead page_news">
+                    <h1 class="pageTitle page_news">NEWS</h1>
+                </div>
+            </div> <!-- /.contentsSidePadding -->
+        </div> <!-- /.contentsMaxWidth -->
     </header> <!-- /#pageHead -->
 
     <div id="pageBody" class="page_news">
         <div class="contentsMaxWidth page_news">
-            <div class="pageBodyFlexbox page_news">
-    
-                <main class="mainColumn page_news">
-                    <article>
-                        <div class="articleTop page_news">
-                            <div class="articleTitAndCat page_news">
-                                <h2 class="articleTitle page_news">店内開発スペースのパソコンが新しくなりました。</h2>
-                                <table class="articleCategory page_news">
-                                    <tr>
-                                        <th>カテゴリー：</th>
-                                        <td>お店の紹介</td>
-                                    </tr>
-                                </table>
-                            </div>
-                            <div class="articleDate page_news">
-                                <div class="articleMMDD page_news"><time datetime="2019-04-01">4/01</time></div>
-                                <div class="articleYYYY page_news">2019</div>
-                            </div>
-                        </div> <!-- /.articleTop -->
-                        <img src="./images/news/wall.jpg" width="1600" height="1010" alt="" class="articlePicture page_news">
-                        <p>
-                            脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
-                            脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
-                        </p>
-                        <p>
-                            脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
-                            脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
-                            脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
-                        </p>
-                        <p>
-                            脳に刺激を与える食品を提供する、GFTD CAFE。
-                        </p>
-                    </article>
-                </main>
+            <div class="contentsSidePadding page_news">
+                <div class="pageBodyFlexbox page_news">
         
-                <aside class="subColumn page_news">
-                    <div class="subColumnFlexbox page_news">
-                        <section class="cyanSection page_news">
-                            <h2 class="cyanSectionHeading page_news">カテゴリー</h2>
-                            <nav class="categoryNavi page_news">
-                                <ul>
-                                    <li><a href="./hogehoge.html#hoge">お店の紹介</a></li>
-                                    <li><a href="./hogehoge.html#hoge">期間限定メニュー</a></li>
-                                    <li><a href="./hogehoge.html#hoge">イベント</a></li>
-                                    <li><a href="./hogehoge.html#hoge">お客様との会話</a></li>
-                                </ul>
-                            </nav>
-                        </section>
-                        <section class="cyanSection page_news">
-                            <h2 class="cyanSectionHeading page_news">このお店について</h2>
+                    <main class="mainColumn page_news">
+                        <article>
+                            <div class="articleTop page_news">
+                                <div class="articleTitAndCat page_news">
+                                    <h2 class="articleTitle page_news">店内開発スペースのパソコンが新しくなりました。</h2>
+                                    <table class="articleCategory page_news">
+                                        <tr>
+                                            <th>カテゴリー：</th>
+                                            <td>お店の紹介</td>
+                                        </tr>
+                                    </table>
+                                </div>
+                                <div class="articleDate page_news">
+                                    <div class="articleMMDD page_news"><time datetime="2019-04-01">4/01</time></div>
+                                    <div class="articleYYYY page_news">2019</div>
+                                </div>
+                            </div> <!-- /.articleTop -->
+                            <img src="./images/news/wall.jpg" width="1600" height="1010" alt="" class="articlePicture page_news">
                             <p>
                                 脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
+                                脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
                             </p>
-                        </section>
-                    </div> <!-- /.subColumnFlexbox -->
-                </aside>
-    
-            </div> <!-- /.pageBodyFlexbox -->
+                            <p>
+                                脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
+                                脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
+                                脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
+                            </p>
+                            <p>
+                                脳に刺激を与える食品を提供する、GFTD CAFE。
+                            </p>
+                        </article>
+                    </main>
+            
+                    <aside class="subColumn page_news">
+                        <div class="subColumnFlexbox page_news">
+                            <section class="cyanSection page_news">
+                                <h2 class="cyanSectionHeading page_news">カテゴリー</h2>
+                                <nav class="categoryNavi page_news">
+                                    <ul>
+                                        <li><a href="./hogehoge.html#hoge">お店の紹介</a></li>
+                                        <li><a href="./hogehoge.html#hoge">期間限定メニュー</a></li>
+                                        <li><a href="./hogehoge.html#hoge">イベント</a></li>
+                                        <li><a href="./hogehoge.html#hoge">お客様との会話</a></li>
+                                    </ul>
+                                </nav>
+                            </section>
+                            <section class="cyanSection page_news">
+                                <h2 class="cyanSectionHeading page_news">このお店について</h2>
+                                <p>
+                                    脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
+                                </p>
+                            </section>
+                        </div> <!-- /.subColumnFlexbox -->
+                    </aside>
+        
+                </div> <!-- /.pageBodyFlexbox -->
+            </div> <!-- contentsSidePadding -->
         </div> <!-- /.contentsMaxWidth -->
     </div> <!-- /#pageBody -->
 
     <footer id="pageFoot" class="page_news">
         <div class="contentsMaxWidth page_news">
-            <p id="copyright" class="page_news"><small>&copy; 2019 GFTD.WORKS</small></p>
+            <div class="contentsSidePadding page_news">
+                <p id="copyright" class="page_news"><small>&copy; 2019 GFTD.WORKS</small></p>
+            </div>
         </div>
     </footer>
 

--- a/news.html
+++ b/news.html
@@ -24,95 +24,94 @@
 <div id="page" class="page_news">
 
     <header id="pageHead" class="page_news">
-        <div class="contentsMaxWidth page_news">
-            <div class="contentsSidePadding page_news">
-                <div class="globalHead page_news">
-                    <a href="./index.html#page"><img src="./images/common/logo.svg" width="426" height="148" alt="GFTD.CAFE" title="GFTD.CAFE トップページ" class="siteLogo page_news"></a>
-                    <nav class="globalNavi page_news">
-                        <ul>
-                            <li><a href="#page">NEWS</a></li>
-                            <li><a href="./menu.html#page">MENU</a></li>
-                            <li><a href="./contact.html#page">CONTACT</a></li>
-                        </ul>
-                    </nav>
-                </div>
-                <div class="localHead page_news">
-                    <h1 class="pageTitle page_news">NEWS</h1>
-                </div>
-            </div> <!-- /.contentsSidePadding -->
+        <div class="contentsMaxWidth contentsSidePadding page_news">
+
+            <div id="globalHead" class="page_news">
+                <a href="./index.html#page"><img src="./images/common/logo.svg" width="426" height="148" alt="GFTD.CAFE" title="GFTD.CAFE トップページ" class="siteLogo page_news"></a>
+                <nav class="globalNavi page_news">
+                    <ul>
+                        <li><a href="#page">NEWS</a></li>
+                        <li><a href="./menu.html#page">MENU</a></li>
+                        <li><a href="./contact.html#page">CONTACT</a></li>
+                    </ul>
+                </nav>
+            </div>
+            <div id="localHead" class="page_news">
+                <h1 class="pageTitle page_news">NEWS</h1>
+            </div>
+
         </div> <!-- /.contentsMaxWidth -->
     </header> <!-- /#pageHead -->
 
     <div id="pageBody" class="page_news">
-        <div class="contentsMaxWidth page_news">
-            <div class="contentsSidePadding page_news">
-                <div class="pageBodyFlexbox page_news">
-        
-                    <main class="mainColumn page_news">
-                        <article>
-                            <div class="articleTop page_news">
-                                <div class="articleTitAndCat page_news">
-                                    <h2 class="articleTitle page_news">店内開発スペースのパソコンが新しくなりました。</h2>
-                                    <table class="articleCategory page_news">
-                                        <tr>
-                                            <th>カテゴリー：</th>
-                                            <td>お店の紹介</td>
-                                        </tr>
-                                    </table>
-                                </div>
-                                <div class="articleDate page_news">
-                                    <div class="articleMMDD page_news"><time datetime="2019-04-01">4/01</time></div>
-                                    <div class="articleYYYY page_news">2019</div>
-                                </div>
-                            </div> <!-- /.articleTop -->
-                            <img src="./images/news/wall.jpg" width="1600" height="1010" alt="" class="articlePicture page_news">
+        <div class="contentsMaxWidth contentsSidePadding page_news">
+            <div class="pageBodyFlexbox page_news">
+
+                <main class="mainColumn page_news">
+                    <article>
+                        <div class="articleTop page_news">
+                            <div class="articleTitAndCat page_news">
+                                <h2 class="articleTitle page_news">店内開発スペースのパソコンが新しくなりました。</h2>
+                                <table class="articleCategory page_news">
+                                    <tr>
+                                        <th>カテゴリー：</th>
+                                        <td>お店の紹介</td>
+                                    </tr>
+                                </table>
+                            </div>
+                            <div class="articleDate page_news">
+                                <div class="articleMMDD page_news"><time datetime="2019-04-01">4/01</time></div>
+                                <div class="articleYYYY page_news">2019</div>
+                            </div>
+                        </div> <!-- /.articleTop -->
+                        <img src="./images/news/wall.jpg" width="1600" height="1010" alt="" class="articlePicture page_news">
+                        <p>
+                            脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
+                            脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
+                        </p>
+                        <p>
+                            脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
+                            脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
+                            脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
+                        </p>
+                        <p>
+                            脳に刺激を与える食品を提供する、GFTD CAFE。
+                        </p>
+                    </article>
+                </main> <!-- /.mainColumn -->
+
+                <aside class="subColumn page_news">
+                    <div class="subColumnFlexbox page_news">
+
+                        <section class="cyanSection page_news">
+                            <h2 class="cyanSectionHeading page_news">カテゴリー</h2>
+                            <nav class="categoryNavi page_news">
+                                <ul>
+                                    <li><a href="./hogehoge.html#hoge">お店の紹介</a></li>
+                                    <li><a href="./hogehoge.html#hoge">期間限定メニュー</a></li>
+                                    <li><a href="./hogehoge.html#hoge">イベント</a></li>
+                                    <li><a href="./hogehoge.html#hoge">お客様との会話</a></li>
+                                </ul>
+                            </nav>
+                        </section>
+
+                        <section class="cyanSection page_news">
+                            <h2 class="cyanSectionHeading page_news">このお店について</h2>
                             <p>
                                 脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
-                                脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
                             </p>
-                            <p>
-                                脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
-                                脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
-                                脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
-                            </p>
-                            <p>
-                                脳に刺激を与える食品を提供する、GFTD CAFE。
-                            </p>
-                        </article>
-                    </main>
-            
-                    <aside class="subColumn page_news">
-                        <div class="subColumnFlexbox page_news">
-                            <section class="cyanSection page_news">
-                                <h2 class="cyanSectionHeading page_news">カテゴリー</h2>
-                                <nav class="categoryNavi page_news">
-                                    <ul>
-                                        <li><a href="./hogehoge.html#hoge">お店の紹介</a></li>
-                                        <li><a href="./hogehoge.html#hoge">期間限定メニュー</a></li>
-                                        <li><a href="./hogehoge.html#hoge">イベント</a></li>
-                                        <li><a href="./hogehoge.html#hoge">お客様との会話</a></li>
-                                    </ul>
-                                </nav>
-                            </section>
-                            <section class="cyanSection page_news">
-                                <h2 class="cyanSectionHeading page_news">このお店について</h2>
-                                <p>
-                                    脳に刺激を与える食品を提供する、GFTD CAFE。刺激のある食材を利用したメニューが特徴です。苦いブレンドコーヒーと辛いジャンクフードで脳の内側から刺激されてください。
-                                </p>
-                            </section>
-                        </div> <!-- /.subColumnFlexbox -->
-                    </aside>
-        
-                </div> <!-- /.pageBodyFlexbox -->
-            </div> <!-- contentsSidePadding -->
+                        </section>
+
+                    </div> <!-- /.subColumnFlexbox -->
+                </aside> <!-- /.sideColumn -->
+
+            </div> <!-- /.pageBodyFlexbox -->
         </div> <!-- /.contentsMaxWidth -->
     </div> <!-- /#pageBody -->
 
     <footer id="pageFoot" class="page_news">
-        <div class="contentsMaxWidth page_news">
-            <div class="contentsSidePadding page_news">
-                <p id="copyright" class="page_news"><small>&copy; 2019 GFTD.WORKS</small></p>
-            </div>
+        <div class="contentsMaxWidth contentsSidePadding page_news">
+            <p id="copyright" class="page_news"><small>&copy; 2019 GFTD.WORKS</small></p>
         </div>
     </footer>
 


### PR DESCRIPTION
1. #pageHeadWrap>#pageHeadを削除し、#pageHead>.contentsMaxWidthに変更。#pageBodyと#pageFootも同様
2. モバイル用のコンテンツの左右のパディングを、コンテンツごとで設定するのではなく、div.contentsSidePaddingで一括に設定
3. idとclassを整理
This merge resolves #11.